### PR TITLE
Add OpenSearch description

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -49,6 +49,7 @@ const MyApp: React.FunctionComponent<MyAppProps> = (props) => {
         <meta />
         <meta name="robots" content="all" />
         <link rel="icon" href="/favicon.png" />
+        <link rel="search" type="application/opensearchdescription+xml" title="Search nix function on noogle" href="/search.xml"></link>
       </Head>
 
       <CacheProvider value={emotionCache}>

--- a/public/search.xml
+++ b/public/search.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>Noogle</ShortName>
+    <Description>Search for nix functions by name.</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/png">https://noogle.dev/favicon.png</Image>
+    <Url type="text/html" template="https://noogle.dev/?term=%22{searchTerms}%22"/>
+    <moz:SearchForm>https://noogle.dev</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
This should allow users to add noogle search to their browser toolbar. See [mdn](https://developer.mozilla.org/en-US/docs/Web/OpenSearch#autodiscovery_of_search_plugins) or source of search.nixos.org.

I've noticed that noogle does not currently handle unquoted terms, i.e. `https://noogle.dev?term=trace` does not yield results, while `https://noogle.dev/?term="trace"` does. ~Hope i got the quoting right in xml~ - (i hadn't)

Thanks for your work on noogle, it's such a useful project :tada: 